### PR TITLE
Default Whisper GPU transcription to use previous context

### DIFF
--- a/Whisper_for_Meeting.ipynb
+++ b/Whisper_for_Meeting.ipynb
@@ -346,7 +346,7 @@
     "        task=\"transcribe\",\n",
     "        language=language_code,\n",
     "        temperature=0.0,\n",
-    "        condition_on_previous_text=False,\n",
+    "        condition_on_previous_text=True,\n",
     "        compression_ratio_threshold=2.4,\n",
     "        log_prob_threshold=-1.0,\n",
     "        no_speech_threshold=0.6,\n",


### PR DESCRIPTION
## Summary
- ensure the `transcribe_gpu` helper keeps `condition_on_previous_text` enabled so Whisper maintains language continuity between segments

## Testing
- python - <<'PY'
from faster_whisper import WhisperModel
model = WhisperModel('tiny', device='cpu')
segments, info = model.transcribe('sample_zh.wav', language='zh', condition_on_previous_text=True, temperature=0.0)
print('Detected language:', info.language, 'prob:', info.language_probability)
text = ''.join(segment.text for segment in segments)
print('Transcript:', text)
PY


------
https://chatgpt.com/codex/tasks/task_e_68d17d80641883319a3296333db840a6