### PR TITLE
Fix harmony formatter call

### DIFF
--- a/Whisper_for_Meeting.ipynb
+++ b/Whisper_for_Meeting.ipynb
@@ -808,7 +808,7 @@
     "        raise RuntimeError(\"LLM model is not loaded. Cannot stream generation.\")\n",
     "    formatter = ensure_harmony_formatter()\n",
     "    chat_response = formatter(\n",
-    "        messages,\n",
+    "        messages=messages,\n",
     "        add_generation_prompt=True,\n",
     "    )\n",
     "\n",


### PR DESCRIPTION
## Summary
- ensure the Harmony chat formatter is invoked with keyword arguments so it matches the current llama.cpp API

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d43e5411108331bb29abdf15b67519